### PR TITLE
return named object reference instead of "this"

### DIFF
--- a/node-bitvavo-api.js
+++ b/node-bitvavo-api.js
@@ -466,7 +466,7 @@ let api = function Bitvavo () {
     })
   }
 
-  return {
+  const apiObject = {
     getEmitter: function () {
       emitterReturned = true
       return emitter
@@ -653,7 +653,7 @@ let api = function Bitvavo () {
         }
       }
       this.reconnectTimer = 100
-      return this
+      return apiObject
     },
     websocket: {
       checkSocket: async function () {
@@ -905,5 +905,7 @@ let api = function Bitvavo () {
       }
     }
   }
+
+  return apiObject
 }
 module.exports = api


### PR DESCRIPTION
The `options` object returns `this`, which by my code editor is recognized as the `options` object itself and not the parent object that it should reference to. To avoid this scoping error, I've made the parent object a declared constant so we can directly reference to it.