### PR TITLE
ci: use release token to publish new SDKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,23 +14,31 @@ permissions:
   contents: write
 
 jobs:
-  validate:
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.release_token }}
+
       - name: Set author in Git
         run: |
-          git config --local user.email 71278578+bitvavo-bot@users.noreply.github.com
-          git config --local user.name bitvavo-bot
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.node_version }}
+
       - run: npm ci
+
       - name: Bump version
         run: npm version ${{ github.event.inputs.version }}
+
       - name: Push release commit
         run: git push --tags origin ${{ github.ref_name }}
+
       - uses: ncipollo/release-action@v1
         with:
           tag: v${{ github.event.inputs.version }}


### PR DESCRIPTION
Uses a `release_token` in order to release the SDK.